### PR TITLE
Configure Vercel deployment with serverless API + reminder cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.pnpm-store/
+dist/
+build/
+.env
+.env.local
+.DS_Store
+*.log
+.vercel

--- a/README.md
+++ b/README.md
@@ -161,6 +161,39 @@ pnpm dev                  # Starts at http://localhost:5000
 
 ---
 
+## Deploying to Vercel
+
+This repo is configured to deploy on Vercel. The frontend builds to a static bundle served from Vercel's CDN, the Express + tRPC API runs as a serverless function under `/api/*`, and the 15-minute reminder job runs as a Vercel Cron.
+
+### One-time setup
+
+1. **Vercel** → **Add New** → **Project** → import `our-brothers-keeper` from GitHub.
+2. In the import screen, set **Root Directory** to `my-brothers-keeper`.
+3. Under **Environment Variables**, add the values listed below.
+4. Click **Deploy**.
+
+### Required environment variables
+
+| Variable | Where to get it | Notes |
+|---|---|---|
+| `DATABASE_URL` | Neon → project → Connection string | Use the **pooled** connection string for serverless |
+| `SESSION_SECRET` | Generate a random string | `openssl rand -hex 32` |
+| `CRON_SECRET` | Generate a random string | Used to authenticate the reminder cron |
+| `REPLIT_DOMAINS` | Your Vercel domain | e.g. `your-app.vercel.app` |
+| `REPL_ID` | Your Replit app's ID | Required by Replit Auth until it's swapped out |
+| `ISSUER_URL` | `https://replit.com/oidc` | Default for Replit Auth |
+| `OWNER_OPEN_ID` | Your Replit user ID | Identifies the project owner |
+| `RESEND_API_KEY` | resend.com dashboard | Required for email reminders |
+| `NODE_ENV` | `production` | |
+
+### Known limitations on Vercel
+
+- **File uploads are non-functional** until `server/objectStorage.ts` is swapped from Replit Object Storage to S3/R2. See "Where Help Is Most Needed" above — this is a contributor task.
+- **Hourly auto-promotion is disabled** on Vercel. The 15-minute reminder cron is wired up; auto-promotion can be added as a second cron entry in `vercel.json` once contributors prioritize it.
+- **Replit Auth still requires `REPLIT_DOMAINS` and `REPL_ID`.** Until auth is migrated, sign-in flows through Replit's OIDC service.
+
+---
+
 ## Repository Structure
 
 ```

--- a/my-brothers-keeper/api/index.ts
+++ b/my-brothers-keeper/api/index.ts
@@ -1,0 +1,10 @@
+import "dotenv/config";
+import type { IncomingMessage, ServerResponse } from "http";
+import { createApp } from "../server/_core/app";
+
+const appPromise = createApp();
+
+export default async function handler(req: IncomingMessage, res: ServerResponse) {
+  const app = await appPromise;
+  return (app as unknown as (req: IncomingMessage, res: ServerResponse) => void)(req, res);
+}

--- a/my-brothers-keeper/server/_core/app.ts
+++ b/my-brothers-keeper/server/_core/app.ts
@@ -1,0 +1,89 @@
+import * as Sentry from "@sentry/node";
+import express, { type Express } from "express";
+import { createExpressMiddleware } from "@trpc/server/adapters/express";
+import { setupAuth, isAuthenticated } from "../replitAuth";
+import { setupTestAuth } from "../testAuth";
+import { appRouter } from "../routers";
+import { createContext } from "./context";
+import uploadRouter from "../uploadRouter";
+import { getUser } from "../db";
+import { processReminders } from "../reminderProcessor";
+import { ObjectStorageService, ObjectNotFoundError } from "../objectStorage";
+
+if (process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    integrations: [Sentry.httpIntegration(), Sentry.expressIntegration()],
+    tracesSampleRate: 1.0,
+    environment: process.env.NODE_ENV || "development",
+  });
+}
+
+export async function createApp(): Promise<Express> {
+  const app = express();
+
+  if (process.env.SENTRY_DSN) {
+    Sentry.setupExpressErrorHandler(app);
+  }
+
+  app.use(express.json({ limit: "50mb" }));
+  app.use(express.urlencoded({ limit: "50mb", extended: true }));
+
+  app.get("/api/cron/reminders", async (req, res) => {
+    const expected = `Bearer ${process.env.CRON_SECRET ?? ""}`;
+    if (!process.env.CRON_SECRET || req.headers.authorization !== expected) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+    try {
+      await processReminders();
+      res.json({ ok: true });
+    } catch (error) {
+      console.error("[Cron] processReminders error:", error);
+      res.status(500).json({ error: "Failed" });
+    }
+  });
+
+  await setupAuth(app);
+  await setupTestAuth(app);
+
+  app.get("/api/auth/user", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user.claims.sub;
+      const user = await getUser(userId);
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+      res.json(user);
+    } catch (error) {
+      console.error("Error fetching user:", error);
+      res.status(500).json({ message: "Failed to fetch user" });
+    }
+  });
+
+  app.use("/api", uploadRouter);
+  app.use("/uploads", express.static("uploads"));
+
+  app.get("/objects/:objectPath(*)", async (req, res) => {
+    try {
+      const objectStorageService = new ObjectStorageService();
+      const objectFile = await objectStorageService.getObjectEntityFile(req.path);
+      await objectStorageService.downloadObject(objectFile, res);
+    } catch (error) {
+      console.error("Error serving object:", error);
+      if (error instanceof ObjectNotFoundError) {
+        return res.status(404).json({ error: "File not found" });
+      }
+      return res.status(500).json({ error: "Error serving file" });
+    }
+  });
+
+  app.use(
+    "/api/trpc",
+    createExpressMiddleware({
+      router: appRouter,
+      createContext,
+    })
+  );
+
+  return app;
+}

--- a/my-brothers-keeper/server/_core/index.ts
+++ b/my-brothers-keeper/server/_core/index.ts
@@ -1,105 +1,20 @@
 import "dotenv/config";
-import * as Sentry from "@sentry/node";
-import express from "express";
 import { createServer } from "http";
-import { createExpressMiddleware } from "@trpc/server/adapters/express";
-import { setupAuth, isAuthenticated } from "../replitAuth";
-import { setupTestAuth } from "../testAuth";
-import { appRouter } from "../routers";
-import { createContext } from "./context";
+import { createApp } from "./app";
 import { serveStatic, setupVite } from "./vite";
-import uploadRouter from "../uploadRouter";
-import { getUser } from "../db";
 import { processAutoPromotions } from "../autoPromotion";
 import { processReminders } from "../reminderProcessor";
 import { ENV } from "./env";
-import { ObjectStorageService, ObjectNotFoundError } from "../objectStorage";
-
-if (process.env.SENTRY_DSN) {
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    integrations: [
-      Sentry.httpIntegration(),
-      Sentry.expressIntegration(),
-    ],
-    tracesSampleRate: 1.0,
-    environment: process.env.NODE_ENV || "development",
-  });
-}
 
 async function startServer() {
-  const app = express();
-  const server = createServer(app);
-  
-  // Log object storage configuration on startup
   console.log("[ObjectStorage] Configuration:", {
     PRIVATE_OBJECT_DIR: process.env.PRIVATE_OBJECT_DIR || "NOT SET",
     PUBLIC_OBJECT_SEARCH_PATHS: process.env.PUBLIC_OBJECT_SEARCH_PATHS || "NOT SET",
   });
-  
-  // Sentry error handler must be registered early to capture all requests
-  if (process.env.SENTRY_DSN) {
-    Sentry.setupExpressErrorHandler(app);
-  }
-  
-  // Configure body parser with larger size limit for file uploads
-  app.use(express.json({ limit: "50mb" }));
-  app.use(express.urlencoded({ limit: "50mb", extended: true }));
-  
-  // Setup Replit Auth (includes sessions, passport, and auth routes)
-  await setupAuth(app);
-  
-  // Setup test-only auth endpoints for E2E testing
-  await setupTestAuth(app);
-  
-  // Auth endpoint for frontend
-  app.get('/api/auth/user', isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const user = await getUser(userId);
-      
-      if (!user) {
-        return res.status(404).json({ message: "User not found" });
-      }
-      
-      res.json(user);
-    } catch (error) {
-      console.error("Error fetching user:", error);
-      res.status(500).json({ message: "Failed to fetch user" });
-    }
-  });
-  
-  // File upload endpoint
-  app.use("/api", uploadRouter);
-  
-  // Serve uploaded files
-  app.use("/uploads", express.static("uploads"));
-  
-  // Serve object storage files
-  app.get("/objects/:objectPath(*)", async (req, res) => {
-    try {
-      const objectStorageService = new ObjectStorageService();
-      const objectFile = await objectStorageService.getObjectEntityFile(req.path);
-      await objectStorageService.downloadObject(objectFile, res);
-    } catch (error) {
-      console.error("Error serving object:", error);
-      if (error instanceof ObjectNotFoundError) {
-        return res.status(404).json({ error: "File not found" });
-      }
-      return res.status(500).json({ error: "Error serving file" });
-    }
-  });
-  
-  // tRPC API
-  app.use(
-    "/api/trpc",
-    createExpressMiddleware({
-      router: appRouter,
-      createContext,
-    })
-  );
-  
-  // development mode uses Vite, production mode uses static files
+
+  const app = await createApp();
+  const server = createServer(app);
+
   if (!ENV.isProduction) {
     await setupVite(app, server);
   } else {
@@ -111,51 +26,34 @@ async function startServer() {
   server.listen(port, "0.0.0.0", () => {
     console.log(`Server running on http://0.0.0.0:${port}/`);
     console.log(`Replit Auth enabled`);
-    
-    // Set up auto-promotion background job
-    // Run once on startup to catch any pending promotions
+
     processAutoPromotions()
-      .then(() => {
-        console.log("[AutoPromotion] Initial auto-promotion check completed");
-      })
-      .catch((error) => {
-        console.error("[AutoPromotion] Error during initial auto-promotion check:", error);
-      });
-    
-    // Run every hour (3600000ms)
+      .then(() => console.log("[AutoPromotion] Initial auto-promotion check completed"))
+      .catch((error) => console.error("[AutoPromotion] Error during initial auto-promotion check:", error));
+
     const autoPromotionInterval = setInterval(() => {
-      processAutoPromotions()
-        .catch((error) => {
-          console.error("[AutoPromotion] Error during scheduled auto-promotion:", error);
-        });
+      processAutoPromotions().catch((error) =>
+        console.error("[AutoPromotion] Error during scheduled auto-promotion:", error)
+      );
     }, 3600000);
-    
-    // Set up reminder processing background job
-    // Run once on startup to catch any pending reminders
+
     processReminders()
-      .then(() => {
-        console.log("[Reminders] Initial reminder check completed");
-      })
-      .catch((error) => {
-        console.error("[Reminders] Error during initial reminder check:", error);
-      });
-    
-    // Run every 15 minutes (900000ms) for timely reminder delivery
+      .then(() => console.log("[Reminders] Initial reminder check completed"))
+      .catch((error) => console.error("[Reminders] Error during initial reminder check:", error));
+
     const reminderInterval = setInterval(() => {
-      processReminders()
-        .catch((error) => {
-          console.error("[Reminders] Error during scheduled reminder processing:", error);
-        });
+      processReminders().catch((error) =>
+        console.error("[Reminders] Error during scheduled reminder processing:", error)
+      );
     }, 900000);
-    
-    // Clean up intervals on server shutdown
-    process.on('SIGTERM', () => {
-      console.log('[AutoPromotion] Cleaning up auto-promotion interval');
-      console.log('[Reminders] Cleaning up reminder interval');
+
+    process.on("SIGTERM", () => {
+      console.log("[AutoPromotion] Cleaning up auto-promotion interval");
+      console.log("[Reminders] Cleaning up reminder interval");
       clearInterval(autoPromotionInterval);
       clearInterval(reminderInterval);
     });
-    
+
     console.log("[AutoPromotion] Background job scheduled to run every hour");
     console.log("[Reminders] Background job scheduled to run every 15 minutes");
   });

--- a/my-brothers-keeper/tsconfig.json
+++ b/my-brothers-keeper/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "api/**/*"],
   "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
   "compilerOptions": {
     "incremental": true,

--- a/my-brothers-keeper/vercel.json
+++ b/my-brothers-keeper/vercel.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "vite build",
+  "outputDirectory": "dist/public",
+  "installCommand": "pnpm install --frozen-lockfile=false",
+  "framework": null,
+  "rewrites": [
+    { "source": "/api/trpc/:path*", "destination": "/api" },
+    { "source": "/api/auth/:path*", "destination": "/api" },
+    { "source": "/api/cron/:path*", "destination": "/api" },
+    { "source": "/api/upload", "destination": "/api" },
+    { "source": "/objects/:path*", "destination": "/api" }
+  ],
+  "crons": [
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "*/15 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Extract Express app construction into `createApp()` so it can be reused by both the local dev server and Vercel's serverless runtime
- Add `api/index.ts` — Vercel serverless handler that wraps the Express app
- Add `vercel.json` with `/api/*` rewrites and a 15-minute cron entry pointing at `/api/cron/reminders`
- Add `/api/cron/reminders` endpoint guarded by `CRON_SECRET` so scheduled email reminders keep working without `setInterval`
- Document deployment steps and required env vars in the README, plus known limitations (file uploads, hourly auto-promotion)

## Why
Opening the project to community contributors. Vercel makes it possible to host the live site on the free Hobby tier, paired with the existing Neon Postgres database. The reminder cron preserves the user-facing scheduled-email feature; auto-promotion is a nice-to-have and can be added later as a second cron entry.

## Known limitations after merge
- **File uploads** will return errors until `server/objectStorage.ts` is migrated off Replit Object Storage (already flagged as a contributor task in the README)
- **Hourly auto-promotion** is not wired up on Vercel (still works in local dev). Easy follow-up: add a second cron entry once contributors prioritize it.
- **Replit Auth** still requires `REPLIT_DOMAINS` and `REPL_ID` env vars until auth is migrated (also already flagged as a contributor task)

## Test plan
- [ ] Local dev still works: `cd my-brothers-keeper && pnpm dev` boots on port 5000 with reminders + auto-promotion intervals running
- [ ] `pnpm build` produces `dist/public` (frontend) and `dist/index.js` (server bundle, used for non-Vercel hosts)
- [ ] Import the repo on Vercel with Root Directory `my-brothers-keeper` and the env vars in the README → deployment succeeds and the site loads
- [ ] Manually hit `/api/cron/reminders` with the `Authorization: Bearer $CRON_SECRET` header → returns `{ ok: true }`

https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q)_