### PR TITLE
Document daily reminder cron limitation on Vercel Hobby plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ This repo is configured to deploy on Vercel. The frontend builds to a static bun
 ### Known limitations on Vercel
 
 - **File uploads are non-functional** until `server/objectStorage.ts` is swapped from Replit Object Storage to S3/R2. See "Where Help Is Most Needed" above — this is a contributor task.
-- **Hourly auto-promotion is disabled** on Vercel. The 15-minute reminder cron is wired up; auto-promotion can be added as a second cron entry in `vercel.json` once contributors prioritize it.
+- **Reminders run once per day on the Vercel Hobby (free) plan.** Vercel's free tier limits cron jobs to a minimum interval of one run per day, so `vercel.json` is currently set to `0 0 * * *` (midnight). This means a reminder scheduled for 2:00 PM today won't be sent until midnight the following day — up to 24 hours late. To restore the original 15-minute cadence, upgrade to Vercel Pro and change the schedule in `vercel.json` to `*/15 * * * *`. Alternatively, point an external cron service (cron-job.org, EasyCron, etc.) at `/api/cron/reminders` with the `CRON_SECRET` header.
+- **Hourly auto-promotion is disabled** on Vercel. It can be added as a second cron entry in `vercel.json` once contributors prioritize it (also subject to the Hobby once-per-day limit).
 - **Replit Auth still requires `REPLIT_DOMAINS` and `REPL_ID`.** Until auth is migrated, sign-in flows through Replit's OIDC service.
 
 ---


### PR DESCRIPTION
## Summary

- Vercel's Hobby (free) tier caps cron jobs at once-per-day, so the reminder cron in `vercel.json` had to be set to `0 0 * * *` (midnight) for the deploy to succeed.
- Updates the README's "Known limitations on Vercel" section to explain the user-facing impact (a reminder set for 2:00 PM today won't fire until midnight tomorrow — up to 24 hours late) and lists two ways to restore faster cadence: upgrade to Vercel Pro and switch back to `*/15 * * * *`, or point an external cron service (cron-job.org, EasyCron, etc.) at `/api/cron/reminders`.
- Also corrects the auto-promotion bullet, which previously claimed "the 15-minute reminder cron is wired up" — no longer true on Hobby.

## Test plan

- [ ] Render the README on GitHub and confirm the "Known limitations on Vercel" section reads clearly
- [ ] Confirm no other docs reference a 15-minute reminder cadence that would now be misleading

https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q)_