### PR TITLE
Fix Vercel routing for Replit Auth endpoints

### DIFF
--- a/my-brothers-keeper/vercel.json
+++ b/my-brothers-keeper/vercel.json
@@ -5,16 +5,13 @@
   "installCommand": "pnpm install --frozen-lockfile=false",
   "framework": null,
   "rewrites": [
-    { "source": "/api/trpc/:path*", "destination": "/api" },
-    { "source": "/api/auth/:path*", "destination": "/api" },
-    { "source": "/api/cron/:path*", "destination": "/api" },
-    { "source": "/api/upload", "destination": "/api" },
+    { "source": "/api/:path*", "destination": "/api" },
     { "source": "/objects/:path*", "destination": "/api" }
   ],
   "crons": [
     {
       "path": "/api/cron/reminders",
-                          "schedule": "0 0 * * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Clicking **Sign In** on the deployed site returns a Vercel 404 (`NOT_FOUND`) because Replit Auth registers `/api/login`, `/api/callback`, and `/api/logout` — none of which were matched by the per-path rewrites in `vercel.json`. Vercel was looking for non-existent serverless functions at those paths.
- Replaces the per-path rewrites with a single `/api/:path*` catch-all, so every request under `/api` is routed to the Express app at `api/index.ts` (which already handles all the sub-paths internally).
- Also strips a stray-whitespace formatting artifact from the cron entry.

## Test plan

- [ ] After merge + redeploy, click **Sign In** on the production URL and confirm it redirects to Replit's OIDC login flow (instead of a 404)
- [ ] Confirm tRPC endpoints under `/api/trpc/*` still respond
- [ ] Confirm the daily reminder cron still triggers `/api/cron/reminders` successfully

https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q)_