### PR TITLE
Bundle Vercel serverless function with esbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .pnpm-store/
 dist/
 build/
+my-brothers-keeper/api/index.js
 .env
 .env.local
 .DS_Store

--- a/my-brothers-keeper/server/_vercel/handler.ts
+++ b/my-brothers-keeper/server/_vercel/handler.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import type { IncomingMessage, ServerResponse } from "http";
-import { createApp } from "../server/_core/app";
+import { createApp } from "../_core/app";
 
 const appPromise = createApp();
 

--- a/my-brothers-keeper/tsconfig.json
+++ b/my-brothers-keeper/tsconfig.json
@@ -1,6 +1,6 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "api/**/*"],
-  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
+  "exclude": ["node_modules", "build", "dist", "api", "**/*.test.ts"],
   "compilerOptions": {
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",

--- a/my-brothers-keeper/vercel.json
+++ b/my-brothers-keeper/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "vite build",
+  "buildCommand": "vite build && esbuild server/_vercel/handler.ts --platform=node --format=esm --bundle --packages=external --outfile=api/index.js",
   "outputDirectory": "dist/public",
   "installCommand": "pnpm install --frozen-lockfile=false",
   "framework": null,


### PR DESCRIPTION
## Summary

Vercel runtime logs showed every API request crashing with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/task/my-brothers-keeper/server/_core/app'
```

Root cause: this project is `"type": "module"` (strict ESM), and 39 server files use extensionless relative imports like `import { foo } from "./bar"`. Locally that works because `tsx` is lenient about extensions. On Vercel's strict ESM Node runtime, it fails.

Rather than touch all 39 files to add `.js` extensions, this PR bundles the serverless function with esbuild — same approach the local-dev build already uses for `server/_core/index.ts`. The bundle is a single self-contained file with no runtime module resolution.

## Changes

- Move handler source: `api/index.ts` → `server/_vercel/handler.ts` (so Vercel doesn't try to compile the TS file itself and end up with both `api/index.ts` and `api/index.js`)
- Update `vercel.json` `buildCommand` to add an esbuild step that produces `api/index.js`
- Add `my-brothers-keeper/api/index.js` to `.gitignore` (build artifact)
- Drop `api/**/*` from `tsconfig.json` `include` and add `api` to `exclude` (no source TS files there anymore)

## Test plan

- [x] Bundle succeeds locally: `pnpm exec esbuild server/_vercel/handler.ts --platform=node --format=esm --bundle --packages=external --outfile=api/index.js` produces a 267KB self-contained file
- [ ] After merge + redeploy, `curl https://our-brothers-keeper-my-brothers-kee.vercel.app/api/login` returns a 302 redirect to Replit OIDC instead of 500
- [ ] Sign In button on the deployed site reaches the Replit login flow

https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q)_