### PR TITLE
Add CODE_OF_CONDUCT, PR template, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something is broken or not working as documented
+title: "[Bug] "
+labels: bug
+---
+
+## What happened
+
+<!-- Brief description of the bug. -->
+
+## What you expected to happen
+
+<!-- What should have happened instead? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- Browser / OS:
+- Deployed URL or local dev:
+- Logged-in role (Primary / Admin / Supporter) and tier (Family / Friend / Community), if relevant:
+
+## Screenshots / logs
+
+<!-- Drop any screenshots, error messages from the browser console, or relevant
+     server logs here. Redact anything sensitive. -->
+
+## Additional context
+
+<!-- Anything else that might help us reproduce or understand the issue. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Read before contributing
+    url: https://github.com/CRamZ28/our-brothers-keeper/blob/main/my-brothers-keeper/CONTRIBUTING.md
+    about: Please review CONTRIBUTING.md and PHILOSOPHY.md before opening a feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+---
+
+## The problem
+
+<!-- What user need or pain point does this address?
+     Whose life does it make easier — the grieving family, an admin, a supporter? -->
+
+## Proposed solution
+
+<!-- What would you build? Sketch the rough shape — UI flow, API change,
+     new section in the app, whatever applies. -->
+
+## Alternatives considered
+
+<!-- Other ways to solve this. Why is the proposed solution better? -->
+
+## Alignment with project philosophy
+
+<!-- OBK is intentionally not social media. Before submitting, please skim
+     PHILOSOPHY.md and confirm this feature respects:
+     - No engagement mechanics (no feeds, no streaks, no notifications-for-the-sake-of)
+     - The three-tier visibility system (Family / Friend / Community)
+     - Privacy by default — additive features should never widen access by default
+
+     Briefly note how this proposal aligns with these principles. -->
+
+## Additional context
+
+<!-- Mockups, links, examples from other tools, etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!-- Thanks for contributing to OBK. A few quick things before you submit. -->
+
+## Summary
+
+<!-- What does this PR change, in 1-3 sentences? -->
+
+## Why
+
+<!-- What problem does this solve, or what user need does it address?
+     If this fixes an open issue, link it: "Fixes #123" -->
+
+## Test plan
+
+<!-- How did you verify this works? Concrete steps a reviewer can repeat.
+     Examples:
+     - [ ] Ran `pnpm dev` locally and signed in successfully
+     - [ ] Created a need at "Friend" tier and confirmed Community-tier user can't see it
+     - [ ] Added unit test in `tests/visibility.spec.ts`
+     - [ ] Manually triggered /api/cron/reminders with the CRON_SECRET header  -->
+
+## Screenshots / Recordings
+
+<!-- For UI changes, drop in a before/after screenshot or short Loom.
+     Skip this section for backend-only changes. -->
+
+## Things to check before merge
+
+- [ ] I read [PHILOSOPHY.md](my-brothers-keeper/PHILOSOPHY.md) and this change aligns with it
+- [ ] I followed the Five-Step Security Pattern in `server/visibilityHelpers.ts` for any new endpoints that touch private data
+- [ ] No new dependencies on Replit-specific services (we're trying to remove these, not add more)
+- [ ] No console.log / debug statements left behind

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in **Our Brother's Keeper (OBK)** a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the project and the families it serves
+- Showing empathy toward other community members — and remembering that this project exists to serve grieving families
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Mocking or trivializing grief, loss, or the families this project is built to support
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to ban temporarily or permanently any contributor for behaviors they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a confidential issue or contacting the project maintainer directly through GitHub (@CRamZ28). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.


### PR DESCRIPTION
## Summary

Adds the standard scaffolding contributors expect to find when evaluating an open-source project:

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1 with a small addition specific to OBK's mission (no mocking grief or trivializing loss)
- **`.github/pull_request_template.md`** — nudges PR authors to write a clear summary, why, test plan, and screenshots; includes a checklist for OBK-specific concerns (PHILOSOPHY alignment, Five-Step Security Pattern, no new Replit deps)
- **`.github/ISSUE_TEMPLATE/bug_report.md`** — structured bug template with role/tier context fields
- **`.github/ISSUE_TEMPLATE/feature_request.md`** — feature template that asks contributors to align with PHILOSOPHY before submitting
- **`.github/ISSUE_TEMPLATE/config.yml`** — links to CONTRIBUTING.md from the new-issue page

## Companion work (already done)

Six GitHub issues opened to give contributors clear places to start: #7 (Replit Auth), #8 (Object Storage), #9 (CI), #10 (TS errors), #11 (visibility tests), #12 (a11y audit).

## Test plan

- [ ] Open a new issue from the GitHub UI → confirm both templates appear in the chooser
- [ ] Open a draft PR → confirm the template prefills the description
- [ ] Render `CODE_OF_CONDUCT.md` on GitHub and confirm it displays correctly

https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q)_