### PR TITLE
Add session callback to populate user.id

### DIFF
--- a/my-brothers-keeper/api/index.js
+++ b/my-brothers-keeper/api/index.js
@@ -673,6 +673,7 @@ function buildAuthConfig() {
     throw new Error("RESEND_API_KEY is required to send magic-link emails");
   }
   return {
+    basePath: "/api/auth",
     adapter: DrizzleAdapter(db, {
       usersTable: users,
       accountsTable: accounts,
@@ -687,7 +688,19 @@ function buildAuthConfig() {
         apiKey: process.env.RESEND_API_KEY,
         from: process.env.AUTH_EMAIL_FROM ?? "Our Brother's Keeper <notifications@obkapp.com>"
       })
-    ]
+    ],
+    callbacks: {
+      async redirect({ url, baseUrl }) {
+        if (url.startsWith(baseUrl)) return url;
+        return baseUrl + "/dashboard";
+      },
+      async session({ session, user }) {
+        if (session.user && user?.id) {
+          session.user.id = user.id;
+        }
+        return session;
+      }
+    }
   };
 }
 function getAuthConfig() {

--- a/my-brothers-keeper/server/auth.ts
+++ b/my-brothers-keeper/server/auth.ts
@@ -60,6 +60,12 @@ function buildAuthConfig() {
         if (url.startsWith(baseUrl)) return url;
         return baseUrl + "/dashboard";
       },
+      async session({ session, user }) {
+        if (session.user && user?.id) {
+          session.user.id = user.id;
+        }
+        return session;
+      },
     },
   };
 }


### PR DESCRIPTION
## Summary

Magic-link sign-in completes successfully (session row written to Neon, `__Secure-authjs.session-token` cookie set in browser), but the frontend still shows "Sign In" after redirecting back. Diagnostic at `https://obkapp.com/api/auth/session` returned:

```json
{"user":{"name":null,"email":"c.ramsey28@gmail.com","image":null},"expires":"2026-07-05T03:49:47.204Z"}
```

**No `id` field on `user`.** Auth.js's default session shape doesn't include user.id — it has to be added via a `callbacks.session`. My code in `getSessionUserId()` reads `session.user.id`, gets `undefined`, and the tRPC context treats every authenticated request as anonymous.

## Fix

Add a `callbacks.session` that copies `user.id` (the DB user record passed as the second arg, since we're using `session: { strategy: "database" }`) onto `session.user`. Standard Auth.js convention — required whenever the app needs to know who's signed in beyond just an email.

## Test plan

- [x] esbuild bundle rebuilds (257.0kb)
- [ ] After merge + redeploy: `curl https://obkapp.com/api/auth/session` with valid session cookie returns `user.id` populated
- [ ] After merge + redeploy: clearing cookies + signing in fresh → frontend recognizes the session and shows authenticated UI (not the "Sign In" button)

https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN1gimGxBkHJauqZkove3Q)_